### PR TITLE
Adds missing methods to myo.DeviceListener

### DIFF
--- a/myo/__init__.py
+++ b/myo/__init__.py
@@ -293,6 +293,18 @@ class DeviceListener(object):
     def on_emg(self, myo, timestamp, emg):
         pass
 
+    def on_unsync(self, myo, timestamp):
+        pass
+
+    def on_sync(self, myo, timestamp, arm, x_direction):
+        pass
+
+    def on_unlock(self, myo, timestamp):
+        pass
+
+    def on_lock(self, myo, timestamp):
+        pass
+
 class Event(object):
     r""" Copy of a Myo SDK event object that can be accessed even
     after the event has been destroyed. Must be constructed with


### PR DESCRIPTION
The DeviceListener base class was missing methods on_sync, on_unsync, on_connect, on_unlock, and on_lock. The bug was hidden in the example code, since the DeviceListener subclass implemented those methods. (Curse you, duck typing!) Adding empty implementations of the four methods to `myo.DeviceListener` fixes this bug.